### PR TITLE
Add environment config and charting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Agent Dashboard
+
+This project includes a lightweight dashboard located in the `dashboard` folder.
+It displays recent entries from the `error_logs` and `execution_logs` tables
+stored in Supabase.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Supabase credentials.
+   These variables are read in `dashboard/supabaseClient.js` via
+   `import.meta.env` when using a bundler such as Vite. If you are serving the
+   files directly, you can provide the credentials using global variables
+   `SUPABASE_URL` and `SUPABASE_ANON_KEY` in a script tag.
+
+2. Serve the `dashboard` directory. Any static HTTP server works. For example:
+
+   ```bash
+   npx serve dashboard
+   ```
+
+   or using Python:
+
+   ```bash
+   cd dashboard
+   python3 -m http.server 8080
+   ```
+
+3. Open the served `index.html` in your browser. The dashboard will connect to
+   Supabase and display recent logs.
+
+## Expected Data Schema
+
+The dashboard expects two tables in Supabase:
+
+- **error_logs** – should contain at least `timestamp` and `message` columns.
+- **execution_logs** – should contain `timestamp`, `action`, `symbol`, and
+  `details` columns describing each agent decision.
+
+## Development
+
+The dashboard uses plain React from a CDN. Auto-refresh and charting features
+are implemented in `dashboard/app.js`.

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,140 @@
+import { supabase } from './supabaseClient.js';
+const { useState, useEffect, useRef } = React;
+
+function Dashboard() {
+  const [errors, setErrors] = useState([]);
+  const [executions, setExecutions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const chartRef = useRef(null);
+  const chartInstance = useRef(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      const { data: errorData } = await supabase
+        .from('error_logs')
+        .select('*')
+        .order('timestamp', { ascending: false })
+        .limit(50);
+
+      const { data: execData } = await supabase
+        .from('execution_logs')
+        .select('*')
+        .order('timestamp', { ascending: false })
+        .limit(50);
+
+      setErrors(errorData ?? []);
+      setExecutions(execData ?? []);
+      setLoading(false);
+    }
+    fetchData();
+    const id = setInterval(fetchData, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    const counts = {};
+    errors.forEach((err) => {
+      const day = err.timestamp.split('T')[0];
+      counts[day] = (counts[day] || 0) + 1;
+    });
+    const labels = Object.keys(counts).sort();
+    const data = labels.map((d) => counts[d]);
+
+    if (chartInstance.current) {
+      chartInstance.current.destroy();
+    }
+
+    chartInstance.current = new Chart(chartRef.current, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Errors per day',
+            backgroundColor: 'rgba(255, 99, 132, 0.5)',
+            borderColor: 'rgb(255, 99, 132)',
+            borderWidth: 1,
+            data,
+          },
+        ],
+      },
+      options: {
+        scales: {
+          y: { beginAtZero: true },
+        },
+      },
+    });
+  }, [errors]);
+
+  if (loading) {
+    return React.createElement('div', { className: 'loading' }, 'Loading...');
+  }
+
+  return React.createElement(
+    'div',
+    { className: 'dashboard' },
+    React.createElement('h1', null, 'Agent Dashboard'),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Recent Executions'),
+      React.createElement(
+        'table',
+        null,
+        React.createElement(
+          'thead',
+          null,
+          React.createElement(
+            'tr',
+            null,
+            React.createElement('th', null, 'Timestamp'),
+            React.createElement('th', null, 'Action'),
+            React.createElement('th', null, 'Symbol'),
+            React.createElement('th', null, 'Details')
+          )
+        ),
+        React.createElement(
+          'tbody',
+          null,
+          executions.map((exec, index) =>
+            React.createElement(
+              'tr',
+              { key: index },
+              React.createElement('td', null, exec.timestamp),
+              React.createElement('td', null, exec.action),
+              React.createElement('td', null, exec.symbol),
+              React.createElement('td', null, exec.details)
+            )
+          )
+        )
+      )
+    ),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Recent Errors'),
+      React.createElement(
+        'ul',
+        null,
+        errors.map((err, index) =>
+          React.createElement(
+            'li',
+            { key: index },
+            React.createElement('span', { className: 'error-time' }, err.timestamp),
+            React.createElement('span', { className: 'error-message' }, err.message)
+          )
+        )
+      )
+    ),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Error Chart'),
+      React.createElement('canvas', { ref: chartRef })
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(Dashboard));

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Agent Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -1,0 +1,51 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f7f7f7;
+  color: #333;
+  margin: 0;
+  padding: 0;
+}
+
+h1 {
+  background: #1f2937;
+  color: white;
+  margin: 0;
+  padding: 1rem 2rem;
+}
+
+section {
+  margin: 2rem;
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+th, td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  background: #e5e7eb;
+}
+
+.error-time {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.loading {
+  margin: 2rem;
+}
+
+canvas {
+  max-width: 100%;
+}

--- a/dashboard/supabaseClient.js
+++ b/dashboard/supabaseClient.js
@@ -1,0 +1,11 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+// Read credentials from environment variables provided by a bundler such as
+// Vite. When running without a build step, you can also define global
+// variables `SUPABASE_URL` and `SUPABASE_ANON_KEY` in a script tag.
+const SUPABASE_URL =
+  import.meta.env.VITE_SUPABASE_URL || window.SUPABASE_URL || '';
+const SUPABASE_ANON_KEY =
+  import.meta.env.VITE_SUPABASE_ANON_KEY || window.SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- document dashboard setup and schema in README
- load Supabase credentials from environment variables
- create `.env.example` template
- poll logs every 30 seconds and chart error counts

## Testing
- `git status --short`