### PR TITLE
Add charts and env config to dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Dashboard
+
+This repository includes a simple dashboard for monitoring the crypto agent's activity.
+
+## Prerequisites
+
+- Node.js environment capable of serving static files (e.g. using `npx serve` or `python -m http.server`)
+- A Supabase project containing `execution_logs` and `error_logs` tables
+
+## Setup
+
+1. Copy `.env.example` to `.env` and populate `SUPABASE_URL` and `SUPABASE_ANON_KEY` with your project's credentials.
+2. Serve the contents of the `dashboard` folder:
+   ```bash
+   npx serve dashboard
+   ```
+   or using Python:
+   ```bash
+   python -m http.server --directory dashboard
+   ```
+3. Open `http://localhost:3000` (or the port shown) in your browser.
+
+The dashboard fetches logs every 30 seconds and displays charts of recent activity.
+
+### File overview
+
+- `dashboard/index.html` – entry point loading React and Chart.js
+- `dashboard/app.js` – main application logic for fetching data and rendering charts
+- `dashboard/supabaseClient.js` – Supabase client configured via environment variables or global variables
+
+The expected schema for logs is minimal:
+
+`execution_logs` should include at least `timestamp`, `action`, `symbol` and a `details` field.
+
+`error_logs` should include `timestamp` and `message` fields.
+

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,132 @@
+import { supabase } from './supabaseClient.js';
+const { useState, useEffect, useRef } = React;
+
+function Dashboard() {
+  const [errors, setErrors] = useState([]);
+  const [executions, setExecutions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const chartRef = useRef(null);
+  const chartInstance = useRef(null);
+
+  async function fetchData() {
+    const { data: errorData } = await supabase
+      .from('error_logs')
+      .select('*')
+      .order('timestamp', { ascending: false })
+      .limit(50);
+
+    const { data: execData } = await supabase
+      .from('execution_logs')
+      .select('*')
+      .order('timestamp', { ascending: false })
+      .limit(50);
+
+    setErrors(errorData ?? []);
+    setExecutions(execData ?? []);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+    const counts = executions.reduce((acc, e) => {
+      acc[e.action] = (acc[e.action] || 0) + 1;
+      return acc;
+    }, {});
+    const labels = Object.keys(counts);
+    const data = Object.values(counts);
+    if (chartInstance.current) chartInstance.current.destroy();
+    chartInstance.current = new Chart(chartRef.current, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Executions',
+            data,
+            backgroundColor: '#3b82f6',
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        plugins: { legend: { display: false } },
+      },
+    });
+  }, [executions]);
+
+  if (loading) {
+    return React.createElement('div', { className: 'loading' }, 'Loading...');
+  }
+
+  return React.createElement(
+    'div',
+    { className: 'dashboard' },
+    React.createElement('h1', null, 'Agent Dashboard'),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Execution Summary'),
+      React.createElement('canvas', { ref: chartRef, id: 'execChart' })
+    ),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Recent Executions'),
+      React.createElement(
+        'table',
+        null,
+        React.createElement(
+          'thead',
+          null,
+          React.createElement(
+            'tr',
+            null,
+            React.createElement('th', null, 'Timestamp'),
+            React.createElement('th', null, 'Action'),
+            React.createElement('th', null, 'Symbol'),
+            React.createElement('th', null, 'Details')
+          )
+        ),
+        React.createElement(
+          'tbody',
+          null,
+          executions.map((exec, index) =>
+            React.createElement(
+              'tr',
+              { key: index },
+              React.createElement('td', null, exec.timestamp),
+              React.createElement('td', null, exec.action),
+              React.createElement('td', null, exec.symbol),
+              React.createElement('td', null, exec.details)
+            )
+          )
+        )
+      )
+    ),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Recent Errors'),
+      React.createElement(
+        'ul',
+        null,
+        errors.map((err, index) =>
+          React.createElement(
+            'li',
+            { key: index },
+            React.createElement('span', { className: 'error-time' }, err.timestamp),
+            React.createElement('span', { className: 'error-message' }, err.message)
+          )
+        )
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(Dashboard));

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Agent Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -1,0 +1,52 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f7f7f7;
+  color: #333;
+  margin: 0;
+  padding: 0;
+}
+
+h1 {
+  background: #1f2937;
+  color: white;
+  margin: 0;
+  padding: 1rem 2rem;
+}
+
+section {
+  margin: 2rem;
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+th, td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  background: #e5e7eb;
+}
+
+.error-time {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.loading {
+  margin: 2rem;
+}
+
+canvas {
+  max-width: 100%;
+  height: 300px;
+}

--- a/dashboard/supabaseClient.js
+++ b/dashboard/supabaseClient.js
@@ -1,0 +1,7 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+const env = typeof import.meta !== 'undefined' ? import.meta.env : {};
+const SUPABASE_URL = env.SUPABASE_URL || env.VITE_SUPABASE_URL || window.SUPABASE_URL;
+const SUPABASE_ANON_KEY = env.SUPABASE_ANON_KEY || env.VITE_SUPABASE_ANON_KEY || window.SUPABASE_ANON_KEY;
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- document setup in README
- use environment variables for Supabase credentials with `.env.example`
- auto-refresh dashboard data and show Chart.js chart
- load Chart.js in HTML and style canvas

## Testing
- `git status --short`