### PR TITLE
Add auto-refresh chart and environment-based config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=public-anon-key

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Agent Dashboard
+
+This repository includes a minimal dashboard for monitoring the crypto trading agent. It reads execution and error logs from Supabase and provides a simple interface to review recent activity.
+
+## Requirements
+* A Supabase project with `execution_logs` and `error_logs` tables.
+* A static file server (any tool that can serve HTML files such as `npx serve` or `python3 -m http.server`).
+
+## Setup
+1. Clone this repository.
+2. Copy `.env.example` to `.env` and fill in your Supabase credentials (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`).
+3. Serve the `dashboard` folder using a static server:
+   ```bash
+   npx serve -s dashboard
+   # or
+   python3 -m http.server --directory dashboard
+   ```
+4. Visit the printed local URL and open `index.html`.
+
+### Alternate configuration
+If you are not using a build tool that injects environment variables (e.g. Vite), create a file `dashboard/env.js` with the following content:
+
+```javascript
+window.SUPABASE_URL = 'https://your-project.supabase.co';
+window.SUPABASE_ANON_KEY = 'public-anon-key';
+```
+
+This script is loaded automatically by `index.html` and will be used by `supabaseClient.js`.
+
+## File Overview
+- `dashboard/index.html` – main HTML page that loads React, Chart.js and the app.
+- `dashboard/app.js` – fetches logs from Supabase, updates every 30s and renders a chart of execution actions.
+- `dashboard/style.css` – basic styling.
+- `dashboard/supabaseClient.js` – creates the Supabase client. Reads credentials from environment variables or globals.
+- `.env.example` – copy to `.env` and fill in with your Supabase credentials.
+
+## Expected Schema
+The dashboard expects the following minimal columns:
+
+### `execution_logs`
+- `timestamp` – ISO string or timestamp of the execution.
+- `action` – buy/sell/rebalance or other action.
+- `symbol` – asset symbol traded.
+- `details` – additional JSON or text describing the operation.
+
+### `error_logs`
+- `timestamp` – when the error occurred.
+- `message` – error message text.
+
+## Development
+You can also run the dashboard using Vite for automatic environment injection:
+
+```bash
+cd dashboard
+npm install
+npx vite
+```
+
+The app will be available at the printed local address and reload on changes.

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,143 @@
+import { supabase } from './supabaseClient.js';
+const { useState, useEffect, useRef } = React;
+
+function Dashboard() {
+  const [errors, setErrors] = useState([]);
+  const [executions, setExecutions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const chartRef = useRef(null);
+  const chartInstance = useRef(null);
+
+  async function fetchData() {
+    const { data: errorData } = await supabase
+      .from('error_logs')
+      .select('*')
+      .order('timestamp', { ascending: false })
+      .limit(50);
+
+    const { data: execData } = await supabase
+      .from('execution_logs')
+      .select('*')
+      .order('timestamp', { ascending: false })
+      .limit(50);
+
+    setErrors(errorData ?? []);
+    setExecutions(execData ?? []);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+    const actionCounts = executions.reduce((acc, exec) => {
+      acc[exec.action] = (acc[exec.action] || 0) + 1;
+      return acc;
+    }, {});
+    const labels = Object.keys(actionCounts);
+    const data = Object.values(actionCounts);
+
+    if (chartInstance.current) {
+      chartInstance.current.data.labels = labels;
+      chartInstance.current.data.datasets[0].data = data;
+      chartInstance.current.update();
+    } else {
+      chartInstance.current = new Chart(chartRef.current.getContext('2d'), {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Executions',
+              backgroundColor: '#3b82f6',
+              data,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          scales: {
+            y: {
+              beginAtZero: true,
+              precision: 0,
+            },
+          },
+        },
+      });
+    }
+  }, [executions]);
+
+  if (loading) {
+    return React.createElement('div', { className: 'loading' }, 'Loading...');
+  }
+
+  return React.createElement(
+    'div',
+    { className: 'dashboard' },
+    React.createElement('h1', null, 'Agent Dashboard'),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Execution Summary'),
+      React.createElement('canvas', { id: 'execChart', ref: chartRef })
+    ),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Recent Executions'),
+      React.createElement(
+        'table',
+        null,
+        React.createElement(
+          'thead',
+          null,
+          React.createElement(
+            'tr',
+            null,
+            React.createElement('th', null, 'Timestamp'),
+            React.createElement('th', null, 'Action'),
+            React.createElement('th', null, 'Symbol'),
+            React.createElement('th', null, 'Details')
+          )
+        ),
+        React.createElement(
+          'tbody',
+          null,
+          executions.map((exec, index) =>
+            React.createElement(
+              'tr',
+              { key: index },
+              React.createElement('td', null, exec.timestamp),
+              React.createElement('td', null, exec.action),
+              React.createElement('td', null, exec.symbol),
+              React.createElement('td', null, exec.details)
+            )
+          )
+        )
+      )
+    ),
+    React.createElement(
+      'section',
+      null,
+      React.createElement('h2', null, 'Recent Errors'),
+      React.createElement(
+        'ul',
+        null,
+        errors.map((err, index) =>
+          React.createElement(
+            'li',
+            { key: index },
+            React.createElement('span', { className: 'error-time' }, err.timestamp),
+            React.createElement('span', { className: 'error-message' }, err.message)
+          )
+        )
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(Dashboard));

--- a/dashboard/env.example.js
+++ b/dashboard/env.example.js
@@ -1,0 +1,2 @@
+window.SUPABASE_URL = 'https://your-project.supabase.co';
+window.SUPABASE_ANON_KEY = 'public-anon-key';

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Agent Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- Optional: provide credentials via env.js when not using a build tool -->
+  <script src="env.js" defer></script>
+  <script type="module" src="app.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -1,0 +1,51 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f7f7f7;
+  color: #333;
+  margin: 0;
+  padding: 0;
+}
+
+h1 {
+  background: #1f2937;
+  color: white;
+  margin: 0;
+  padding: 1rem 2rem;
+}
+
+section {
+  margin: 2rem;
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+th, td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  background: #e5e7eb;
+}
+
+.error-time {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.loading {
+  margin: 2rem;
+}
+
+canvas {
+  max-width: 100%;
+}

--- a/dashboard/supabaseClient.js
+++ b/dashboard/supabaseClient.js
@@ -1,0 +1,15 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+// Prefer environment variables injected by a build tool such as Vite.
+// Fall back to globals defined on `window` when served statically.
+const SUPABASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_SUPABASE_URL) ||
+  window.SUPABASE_URL ||
+  'YOUR_SUPABASE_URL';
+
+const SUPABASE_ANON_KEY =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_SUPABASE_ANON_KEY) ||
+  window.SUPABASE_ANON_KEY ||
+  'YOUR_SUPABASE_ANON_KEY';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- document dashboard usage in `README.md`
- provide `.env.example` and `dashboard/env.example.js` for credentials
- load credentials from environment variables or globals
- refresh logs every 30 seconds and show execution chart
- include Chart.js dependency and responsive canvas styling

## Testing
- `git status --short`