### PR TITLE
Add Dockerfile and Docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:lts-alpine
+RUN apk add --no-cache python3 py3-pip
+WORKDIR /app
+COPY . .
+RUN pip3 install --no-cache-dir -r requirements.txt
+RUN npm test && pytest -q
+RUN cp dashboard/env.example.js dashboard/env.js
+EXPOSE 3000
+CMD ["npx", "serve", "dashboard", "-l", "3000"]

--- a/README.md
+++ b/README.md
@@ -52,3 +52,15 @@ Execute the Python and Node checks to ensure the code is valid:
 pytest -q
 npm test
 ```
+
+## Docker
+
+Build the Docker image:
+```bash
+docker build -t dashboard .
+```
+Run the container:
+```bash
+docker run -p 3000:3000 dashboard
+```
+Then open `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs Python dependencies, runs tests and serves the dashboard
- document Docker build and run steps in the README

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b475c46e08325933b4f64318daa03